### PR TITLE
Update MSFT_xADDomain.psm1

### DIFF
--- a/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
+++ b/DSCResources/MSFT_xADDomain/MSFT_xADDomain.psm1
@@ -131,7 +131,7 @@ function Set-TargetResource
         }
         if ($DomainNetbiosName.length -gt 0)
         {
-            $params.Add("NewDomainNetbiosName", $DomainNetbiosName)
+            $params.Add("DomainNetbiosName", $DomainNetbiosName)
         }
         if ($DnsDelegationCredential -ne $null)
         {
@@ -169,7 +169,7 @@ function Set-TargetResource
         }
         if ($DomainNetbiosName.length -gt 0)
         {
-            $params.Add("NewDomainNetbiosName", $DomainNetbiosName)
+            $params.Add("DomainNetbiosName", $DomainNetbiosName)
         }
         if ($DnsDelegationCredential -ne $null)
         {


### PR DESCRIPTION
no such parameter as NewDomainNetbiosName for Install-ADDSForest . this causes errors when creating a new forest.